### PR TITLE
API refactor

### DIFF
--- a/Sources/TweetNacl/Constant.swift
+++ b/Sources/TweetNacl/Constant.swift
@@ -6,20 +6,36 @@
 //  Copyright © 2016 Bitmark. All rights reserved.
 //
 
-internal let crypto_secretbox_KEYBYTES = 32
-internal let crypto_secretbox_NONCEBYTES = 24
-internal let crypto_secretbox_ZEROBYTES = 32
-internal let crypto_secretbox_BOXZEROBYTES = 16
-internal let crypto_scalarmult_BYTES = 32
-internal let crypto_scalarmult_SCALARBYTES = 32
-internal let crypto_box_PUBLICKEYBYTES = 32
-internal let crypto_box_SECRETKEYBYTES = 32
-internal let crypto_box_BEFORENMBYTES = 32
-internal let crypto_box_NONCEBYTES = crypto_secretbox_NONCEBYTES
-internal let crypto_box_ZEROBYTES = crypto_secretbox_ZEROBYTES
-internal let crypto_box_BOXZEROBYTES = crypto_secretbox_BOXZEROBYTES
-internal let crypto_sign_BYTES = 64
-internal let crypto_sign_PUBLICKEYBYTES = 32
-internal let crypto_sign_SECRETKEYBYTES = 64
-internal let crypto_sign_SEEDBYTES = 32
-internal let crypto_hash_BYTES = 64
+struct Constants {
+    struct Box {
+        static let publicKeyBytes = 32
+        static let secretKeyBytes = 32
+        static let beforeNMBytes = 32
+        static let nonceBytes = Secretbox.nonceBytes
+        static let zeroBytes = Secretbox.zeroBytes
+        static let boxZeroBytes = Secretbox.boxZeroBytes
+    }
+
+    struct Hash {
+        static let bytes = 64
+    }
+
+    struct Scalarmult {
+        static let bytes = 32
+        static let scalarBytes = 32
+    }
+
+    struct Secretbox {
+        static let keyBytes = 32
+        static let nonceBytes = 24
+        static let zeroBytes = 32
+        static let boxZeroBytes = 16
+    }
+
+    struct Sign {
+        static let bytes = 64
+        static let publicKeyBytes = 32
+        static let secretKeyBytes = 64
+        static let seedBytes = 32
+    }
+}

--- a/Sources/TweetNacl/TweetNacl.swift
+++ b/Sources/TweetNacl/TweetNacl.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CTweetNacl
 
-struct NaclUtil {
+public struct NaclUtil {
     
     public enum NaclUtilError: Error {
         case badKeySize

--- a/Sources/TweetNacl/TweetNacl.swift
+++ b/Sources/TweetNacl/TweetNacl.swift
@@ -93,14 +93,14 @@ struct NaclUtil {
     }
 }
 
-fileprivate struct NaclWrapper {
+struct NaclWrapper {
     public enum NaclWrapperError: Error {
         case invalidParameters
         case internalError
         case creationFailed
     }
     
-    fileprivate static func crypto_box_keypair(secretKey sk: Data) throws -> (publicKey: Data, secretKey: Data) {
+    static func crypto_box_keypair(secretKey sk: Data) throws -> (publicKey: Data, secretKey: Data) {
         var pk = Data(count: Constants.Box.secretKeyBytes)
         
         let result = pk.withUnsafeMutableBytes({ (pkPointer: UnsafeMutablePointer<UInt8>) -> Int32 in
@@ -116,13 +116,13 @@ fileprivate struct NaclWrapper {
         return (pk, sk)
     }
     
-    fileprivate static func crypto_sign_keypair() throws -> (publicKey: Data, secretKey: Data) {
+    static func crypto_sign_keypair() throws -> (publicKey: Data, secretKey: Data) {
         let sk = try NaclUtil.randomBytes(length: Constants.Sign.secretKeyBytes)
         
         return try crypto_sign_keypair_seeded(secretKey: sk)
     }
     
-    fileprivate static func crypto_sign_keypair_seeded(secretKey: Data) throws -> (publicKey: Data, secretKey: Data) {
+    static func crypto_sign_keypair_seeded(secretKey: Data) throws -> (publicKey: Data, secretKey: Data) {
         var pk = Data(count: Constants.Sign.publicKeyBytes)
         var sk = Data(count: Constants.Sign.secretKeyBytes)
         sk.replaceSubrange(0..<Constants.Sign.publicKeyBytes, with: secretKey.subdata(in: 0..<Constants.Sign.publicKeyBytes))

--- a/Sources/TweetNacl/TweetNacl.swift
+++ b/Sources/TweetNacl/TweetNacl.swift
@@ -83,14 +83,6 @@ struct NaclUtil {
         
         return r == 0
     }
-    
-    public static func encodeBase64(data: Data) -> String {
-        return data.base64EncodedString()
-    }
-    
-    public static func decodeBase64(string: String) -> Data? {
-        return Data(base64Encoded: string)
-    }
 }
 
 struct NaclWrapper {

--- a/Sources/TweetNacl/TweetNacl.swift
+++ b/Sources/TweetNacl/TweetNacl.swift
@@ -21,7 +21,7 @@ struct NaclUtil {
     
     static func checkLengths(key: Data, nonce: Data) throws {
         if key.count != Constants.Secretbox.keyBytes {
-            throw(NaclUtilError.badKeySize)
+            throw NaclUtilError.badKeySize
         }
         
         if nonce.count != Constants.Secretbox.nonceBytes {
@@ -31,11 +31,11 @@ struct NaclUtil {
     
     static func checkBoxLength(publicKey: Data, secretKey: Data) throws {
         if publicKey.count != Constants.Box.publicKeyBytes {
-            throw(NaclUtilError.badPublicKeySize)
+            throw NaclUtilError.badPublicKeySize
         }
         
         if secretKey.count != Constants.Box.secretKeyBytes{
-            throw(NaclUtilError.badSecretKeySize)
+            throw NaclUtilError.badSecretKeySize
         }
     }
     
@@ -45,7 +45,7 @@ struct NaclUtil {
             return SecRandomCopyBytes(kSecRandomDefault, length, $0)
         }
         guard result == errSecSuccess else {
-            throw(NaclUtilError.internalError)
+            throw NaclUtilError.internalError
         }
         
         return data
@@ -60,7 +60,7 @@ struct NaclUtil {
         }
         
         if r != 0 {
-            throw(NaclUtilError.internalError)
+            throw NaclUtilError.internalError
         }
         
         return hash
@@ -184,7 +184,7 @@ public struct NaclSecretBox {
         }
         
         if result != 0 {
-            throw(NaclSecretBoxError.creationFailed)
+            throw NaclSecretBoxError.creationFailed
         }
         
         return m.subdata(in: Constants.Secretbox.zeroBytes..<c.count)
@@ -200,11 +200,11 @@ public struct NaclScalarMult {
     
     public static func scalarMult(n: Data, p: Data) throws -> Data {
         if n.count != Constants.Scalarmult.scalarBytes {
-            throw(NaclScalarMultError.invalidParameters)
+            throw NaclScalarMultError.invalidParameters
         }
         
         if p.count != Constants.Scalarmult.bytes {
-            throw(NaclScalarMultError.invalidParameters)
+            throw NaclScalarMultError.invalidParameters
         }
         
         var q = Data(count: Constants.Scalarmult.bytes)
@@ -218,7 +218,7 @@ public struct NaclScalarMult {
         }
         
         if result != 0 {
-            throw(NaclScalarMultError.creationFailed)
+            throw NaclScalarMultError.creationFailed
         }
         
         return q
@@ -226,7 +226,7 @@ public struct NaclScalarMult {
     
     public static func base(n: Data) throws -> Data {
         if n.count != Constants.Scalarmult.scalarBytes {
-            throw(NaclScalarMultError.invalidParameters)
+            throw NaclScalarMultError.invalidParameters
         }
         
         var q = Data(count: Constants.Scalarmult.bytes)
@@ -238,7 +238,7 @@ public struct NaclScalarMult {
         }
         
         if result != 0 {
-            throw(NaclScalarMultError.creationFailed)
+            throw NaclScalarMultError.creationFailed
         }
         
         return q
@@ -272,7 +272,7 @@ public struct NaclBox {
         }
         
         if result != 0 {
-            throw(NaclBoxError.creationFailed)
+            throw NaclBoxError.creationFailed
         }
         
         return k
@@ -291,7 +291,7 @@ public struct NaclBox {
     
     public static func keyPair(fromSecretKey sk: Data) throws -> (publicKey: Data, secretKey: Data) {
         if sk.count != Constants.Box.secretKeyBytes {
-            throw(NaclBoxError.invalidParameters)
+            throw NaclBoxError.invalidParameters
         }
         
         return try NaclWrapper.crypto_box_keypair(secretKey: sk)
@@ -308,7 +308,7 @@ public struct NaclSign {
     
     public static func sign(message: Data, secretKey: Data) throws -> Data {
         if secretKey.count != Constants.Sign.secretKeyBytes{
-            throw(NaclSignError.invalidParameters)
+            throw NaclSignError.invalidParameters
         }
         
         var signedMessage = Data(count: Constants.Sign.bytes + message.count)
@@ -332,7 +332,7 @@ public struct NaclSign {
     
     public static func signOpen(signedMessage: Data, publicKey: Data) throws -> Data {
         if publicKey.count != Constants.Sign.publicKeyBytes {
-            throw(NaclSignError.invalidParameters)
+            throw NaclSignError.invalidParameters
         }
         
         var tmp = Data(count: signedMessage.count)
@@ -347,7 +347,7 @@ public struct NaclSign {
         }
         
         if result != 0 {
-            throw(NaclSignError.creationFailed)
+            throw NaclSignError.creationFailed
         }
         
         return tmp
@@ -363,11 +363,11 @@ public struct NaclSign {
     
     public static func signDetachedVerify(message: Data, sig: Data, publicKey: Data) throws -> Bool {
         if sig.count != Constants.Sign.bytes {
-            throw(NaclSignError.invalidParameters)
+            throw NaclSignError.invalidParameters
         }
         
         if publicKey.count != Constants.Sign.publicKeyBytes {
-            throw(NaclSignError.invalidParameters)
+            throw NaclSignError.invalidParameters
         }
         
         var sm = Data()
@@ -397,7 +397,7 @@ public struct NaclSign {
         
         public static func keyPair(fromSecretKey secretKey: Data) throws -> (publicKey: Data, secretKey: Data) {
             if secretKey.count != Constants.Sign.secretKeyBytes {
-                throw(NaclSignError.invalidParameters)
+                throw NaclSignError.invalidParameters
             }
             
             let pk = secretKey.subdata(in: Constants.Sign.publicKeyBytes..<Constants.Sign.secretKeyBytes)
@@ -407,7 +407,7 @@ public struct NaclSign {
         
         public static func keyPair(fromSeed seed: Data) throws -> (publicKey: Data, secretKey: Data) {
             if seed.count != Constants.Sign.seedBytes {
-                throw(NaclSignError.invalidParameters)
+                throw NaclSignError.invalidParameters
             }
             
             return try NaclWrapper.crypto_sign_keypair_seeded(secretKey: seed)

--- a/Sources/TweetNacl/TweetNacl.swift
+++ b/Sources/TweetNacl/TweetNacl.swift
@@ -94,7 +94,7 @@ struct NaclUtil {
 }
 
 struct NaclWrapper {
-    public enum NaclWrapperError: Error {
+    enum NaclWrapperError: Error {
         case invalidParameters
         case internalError
         case creationFailed

--- a/Sources/TweetNacl/TweetNacl.swift
+++ b/Sources/TweetNacl/TweetNacl.swift
@@ -58,14 +58,9 @@ public struct NaclUtil {
         #else
 
         var randomData = Data(count: count)
-        let result = try randomData.withUnsafeMutableBytes { bufferPointer -> Int32 in
-            guard let baseAddress = bufferPointer.baseAddress else {
-                throw NaclUtilError.internalError
-            }
-
-            return SecRandomCopyBytes(kSecRandomDefault, count, baseAddress)
+        let result = randomData.withUnsafeMutableBytes {
+            return SecRandomCopyBytes(kSecRandomDefault, count, $0)
         }
-
         guard result == errSecSuccess else {
             throw NaclUtilError.internalError
         }

--- a/Sources/TweetNacl/TweetNacl.swift
+++ b/Sources/TweetNacl/TweetNacl.swift
@@ -414,7 +414,7 @@ public struct NaclSign {
         }
         
         public static func keyPair(fromSeed seed: Data) throws -> (publicKey: Data, secretKey: Data) {
-            if seed.count != 32 {
+            if seed.count != Constants.Sign.seedBytes {
                 throw(NaclSignError.invalidParameters)
             }
             

--- a/Sources/TweetNacl/TweetNacl.swift
+++ b/Sources/TweetNacl/TweetNacl.swift
@@ -9,6 +9,8 @@
 import Foundation
 import CTweetNacl
 
+// MARK: - Utilities
+
 public struct NaclUtil {
     
     public enum NaclUtilError: Error {
@@ -107,6 +109,8 @@ public struct NaclUtil {
     }
 }
 
+// MARK: - Internal wrapper
+
 struct NaclWrapper {
     enum NaclWrapperError: Error {
         case invalidParameters
@@ -154,6 +158,8 @@ struct NaclWrapper {
         return (pk, sk)
     }
 }
+
+// MARK: - Secret-key authenticated encryption
 
 public struct NaclSecretBox {
     public enum NaclSecretBoxError: Error {
@@ -213,6 +219,8 @@ public struct NaclSecretBox {
     }
 }
 
+// MARK: - Scalar multiplication
+
 public struct NaclScalarMult {
     public enum NaclScalarMultError: Error {
         case invalidParameters
@@ -267,6 +275,8 @@ public struct NaclScalarMult {
     }
 }
 
+// MARK: - Public-key authenticated encryption
+
 public struct NaclBox {
     
     public enum NaclBoxError: Error {
@@ -319,6 +329,8 @@ public struct NaclBox {
         return try NaclWrapper.crypto_box_keypair(secretKey: sk)
     }
 }
+
+// MARK: - Signatures
 
 public struct NaclSign {
     

--- a/Tests/TweetNaclTests/NaclBox_Tests.swift
+++ b/Tests/TweetNaclTests/NaclBox_Tests.swift
@@ -26,14 +26,14 @@ class NaclBox_Test: XCTestCase {
     }
     
     func testBox() {
-        let pk = NaclUtil.decodeBase64(string: data![0])!
-        let sk = NaclUtil.decodeBase64(string: data![1])!
-        let msg = NaclUtil.decodeBase64(string: data![2])!
+        let pk = Data(base64Encoded: data![0])!
+        let sk = Data(base64Encoded: data![1])!
+        let msg = Data(base64Encoded: data![2])!
         let goodBox = data![3]
         
         do {
             let box = try NaclBox.box(message: msg, nonce: nonce, publicKey: pk, secretKey: sk)
-            let boxEncoded = NaclUtil.encodeBase64(data: box)
+            let boxEncoded = box.base64EncodedString()
             let open = try NaclBox.open(message: box, nonce: nonce, publicKey: pk, secretKey: sk)
             
             XCTAssertEqual(boxEncoded, goodBox)

--- a/Tests/TweetNaclTests/NaclBox_Tests.swift
+++ b/Tests/TweetNaclTests/NaclBox_Tests.swift
@@ -12,7 +12,7 @@ import XCTest
 class NaclBox_Test: XCTestCase {
     
     public var data: Array<String>?
-    private var nonce = Data(count: crypto_box_NONCEBYTES)
+    private var nonce = Data(count: Constants.Box.nonceBytes)
     
     
     override func setUp() {

--- a/Tests/TweetNaclTests/NaclScalarMulti_Tests.swift
+++ b/Tests/TweetNaclTests/NaclScalarMulti_Tests.swift
@@ -48,25 +48,25 @@ class NaclScalarMulti_Tests: XCTestCase {
     
     func testScalarMulti() {
         let pk1Dec = data![0]
-        let pk1 = NaclUtil.decodeBase64(string: pk1Dec)!
-        let sk1 = NaclUtil.decodeBase64(string: data![1])!
+        let pk1 = Data(base64Encoded: pk1Dec)!
+        let sk1 = Data(base64Encoded: data![1])!
         let pk2Dec = data![2]
-        let pk2 = NaclUtil.decodeBase64(string: pk2Dec)!
-        let sk2 = NaclUtil.decodeBase64(string: data![3])!
+        let pk2 = Data(base64Encoded: pk2Dec)!
+        let sk2 = Data(base64Encoded: data![3])!
         let out = data![4]
         
         do {
             let jpk1 = try NaclScalarMult.base(n: sk1)
-            XCTAssertEqual(NaclUtil.encodeBase64(data: jpk1), pk1Dec)
+            XCTAssertEqual(jpk1.base64EncodedString(), pk1Dec)
             
             let jpk2 = try NaclScalarMult.base(n: sk2)
-            XCTAssertEqual(NaclUtil.encodeBase64(data: jpk2), pk2Dec)
+            XCTAssertEqual(jpk2.base64EncodedString(), pk2Dec)
             
             let jout1 = try NaclScalarMult.scalarMult(n: sk1, p: pk2)
-            XCTAssertEqual(NaclUtil.encodeBase64(data: jout1), out)
+            XCTAssertEqual(jout1.base64EncodedString(), out)
             
             let jout2 = try NaclScalarMult.scalarMult(n: sk2, p: pk1)
-            XCTAssertEqual(NaclUtil.encodeBase64(data: jout2), out)
+            XCTAssertEqual(jout2.base64EncodedString(), out)
         }
         catch {
             XCTFail()

--- a/Tests/TweetNaclTests/NaclSecretbox_Tests.swift
+++ b/Tests/TweetNaclTests/NaclSecretbox_Tests.swift
@@ -26,21 +26,21 @@ class NaclSecretbox_Tests: XCTestCase {
     }
     
     func testSecretBox() {
-        let key = NaclUtil.decodeBase64(string: data![0])!
-        let nonce = NaclUtil.decodeBase64(string: data![1])!
+        let key = Data(base64Encoded: data![0])!
+        let nonce = Data(base64Encoded: data![1])!
         let encodedMessage = data![2]
-        let msg = NaclUtil.decodeBase64(string: encodedMessage)!
+        let msg = Data(base64Encoded: encodedMessage)!
         let goodBox = data![3]
         
         do {
             let box = try NaclSecretBox.secretBox(message: msg, nonce: nonce, key: key)
-            let boxEncoded = NaclUtil.encodeBase64(data: box)
+            let boxEncoded = box.base64EncodedString()
             
             XCTAssertEqual(boxEncoded, goodBox)
             
             let openedBox = try NaclSecretBox.open(box: box, nonce: nonce, key: key)
             XCTAssertNotNil(openedBox)
-            XCTAssertEqual(NaclUtil.encodeBase64(data: openedBox), encodedMessage)
+            XCTAssertEqual(openedBox.base64EncodedString(), encodedMessage)
         }
         catch {
             XCTFail()

--- a/Tests/TweetNaclTests/NaclSign_Tests.swift
+++ b/Tests/TweetNaclTests/NaclSign_Tests.swift
@@ -26,8 +26,8 @@ class NaclSign_Test: XCTestCase {
     func testKeyPair() {
         do {
             let keypair = try NaclSign.KeyPair.keyPair()
-            XCTAssertEqual(keypair.publicKey.count, crypto_sign_PUBLICKEYBYTES)
-            XCTAssertEqual(keypair.secretKey.count, crypto_sign_SECRETKEYBYTES)
+            XCTAssertEqual(keypair.publicKey.count, Constants.Sign.publicKeyBytes)
+            XCTAssertEqual(keypair.secretKey.count, Constants.Sign.secretKeyBytes)
             XCTAssertNotEqual(keypair.secretKey.count, keypair.publicKey.count)
             XCTAssertNotEqual(NaclUtil.encodeBase64(data: keypair.secretKey), NaclUtil.encodeBase64(data: keypair.publicKey))
         }
@@ -69,14 +69,14 @@ class NaclSign_Test: XCTestCase {
     
     func testSignFromSeed() {
         do {
-            let seed = try NaclUtil.randomBytes(length: crypto_sign_SEEDBYTES)
+            let seed = try NaclUtil.randomBytes(length: Constants.Sign.seedBytes)
             let k1 = try NaclSign.KeyPair.keyPair(fromSeed: seed)
             let k2 = try NaclSign.KeyPair.keyPair(fromSeed: seed)
             
-            XCTAssertEqual(k1.secretKey.count, crypto_sign_SECRETKEYBYTES)
-            XCTAssertEqual(k1.publicKey.count, crypto_sign_PUBLICKEYBYTES)
-            XCTAssertEqual(k2.secretKey.count, crypto_sign_SECRETKEYBYTES)
-            XCTAssertEqual(k2.publicKey.count, crypto_sign_PUBLICKEYBYTES)
+            XCTAssertEqual(k1.secretKey.count, Constants.Sign.secretKeyBytes)
+            XCTAssertEqual(k1.publicKey.count, Constants.Sign.publicKeyBytes)
+            XCTAssertEqual(k2.secretKey.count, Constants.Sign.secretKeyBytes)
+            XCTAssertEqual(k2.publicKey.count, Constants.Sign.publicKeyBytes)
             XCTAssertEqual(NaclUtil.encodeBase64(data: k1.secretKey), NaclUtil.encodeBase64(data: k2.secretKey))
             XCTAssertEqual(NaclUtil.encodeBase64(data: k1.publicKey), NaclUtil.encodeBase64(data: k2.publicKey))
         }
@@ -95,7 +95,7 @@ class NaclSign_Test: XCTestCase {
             let message = Data(bytes: bytes, count: 100)
             
             let sig = try NaclSign.signDetached(message: message, secretKey: k.secretKey)
-            XCTAssertEqual(sig.count, crypto_sign_BYTES)
+            XCTAssertEqual(sig.count, Constants.Sign.bytes)
             
             let result = try NaclSign.signDetachedVerify(message: message, sig: sig, publicKey: k.publicKey)
             XCTAssertNotNil(result, "signature must be verified")

--- a/Tests/TweetNaclTests/NaclSign_Tests.swift
+++ b/Tests/TweetNaclTests/NaclSign_Tests.swift
@@ -69,7 +69,7 @@ class NaclSign_Test: XCTestCase {
     
     func testSignFromSeed() {
         do {
-            let seed = try NaclUtil.randomBytes(length: Constants.Sign.seedBytes)
+            let seed = try NaclUtil.secureRandomData(count: Constants.Sign.seedBytes)
             let k1 = try NaclSign.KeyPair.keyPair(fromSeed: seed)
             let k2 = try NaclSign.KeyPair.keyPair(fromSeed: seed)
             
@@ -104,10 +104,10 @@ class NaclSign_Test: XCTestCase {
                 
             XCTAssertThrowsError(try NaclSign.signDetachedVerify(message: message, sig: sig.subdata(in: 0..<1), publicKey: k.publicKey))
             
-            let badPublicKey = try NaclUtil.randomBytes(length: k.publicKey.count)
+            let badPublicKey = try NaclUtil.secureRandomData(count: k.publicKey.count)
             XCTAssertEqual(try NaclSign.signDetachedVerify(message: message, sig: sig, publicKey: badPublicKey), false)
             
-            let badSigKey = try NaclUtil.randomBytes(length: sig.count)
+            let badSigKey = try NaclUtil.secureRandomData(count: sig.count)
             XCTAssertEqual(try NaclSign.signDetachedVerify(message: message, sig: badSigKey, publicKey: k.publicKey), false)
         }
         catch {

--- a/Tests/TweetNaclTests/NaclSign_Tests.swift
+++ b/Tests/TweetNaclTests/NaclSign_Tests.swift
@@ -29,7 +29,7 @@ class NaclSign_Test: XCTestCase {
             XCTAssertEqual(keypair.publicKey.count, Constants.Sign.publicKeyBytes)
             XCTAssertEqual(keypair.secretKey.count, Constants.Sign.secretKeyBytes)
             XCTAssertNotEqual(keypair.secretKey.count, keypair.publicKey.count)
-            XCTAssertNotEqual(NaclUtil.encodeBase64(data: keypair.secretKey), NaclUtil.encodeBase64(data: keypair.publicKey))
+            XCTAssertNotEqual(keypair.secretKey.base64EncodedString(), keypair.publicKey.base64EncodedString())
         }
         catch {
             XCTFail()
@@ -41,8 +41,8 @@ class NaclSign_Test: XCTestCase {
         do {
             let k1 = try NaclSign.KeyPair.keyPair()
             let k2 = try NaclSign.KeyPair.keyPair(fromSecretKey: k1.secretKey)
-            XCTAssertEqual(NaclUtil.encodeBase64(data: k1.secretKey), NaclUtil.encodeBase64(data: k2.secretKey))
-            XCTAssertEqual(NaclUtil.encodeBase64(data: k1.publicKey), NaclUtil.encodeBase64(data: k2.publicKey))
+            XCTAssertEqual(k1.secretKey.base64EncodedString(), k2.secretKey.base64EncodedString())
+            XCTAssertEqual(k1.publicKey.base64EncodedString(), k2.publicKey.base64EncodedString())
         }
         catch {
             XCTFail()
@@ -77,8 +77,8 @@ class NaclSign_Test: XCTestCase {
             XCTAssertEqual(k1.publicKey.count, Constants.Sign.publicKeyBytes)
             XCTAssertEqual(k2.secretKey.count, Constants.Sign.secretKeyBytes)
             XCTAssertEqual(k2.publicKey.count, Constants.Sign.publicKeyBytes)
-            XCTAssertEqual(NaclUtil.encodeBase64(data: k1.secretKey), NaclUtil.encodeBase64(data: k2.secretKey))
-            XCTAssertEqual(NaclUtil.encodeBase64(data: k1.publicKey), NaclUtil.encodeBase64(data: k2.publicKey))
+            XCTAssertEqual(k1.secretKey.base64EncodedString(), k2.secretKey.base64EncodedString())
+            XCTAssertEqual(k1.publicKey.base64EncodedString(), k2.publicKey.base64EncodedString())
         }
         catch {
             XCTFail()


### PR DESCRIPTION
This PR resolves #8 (and makes some additional improvements):

- Refactors `Constant.swift` (7502932)
- Adds a missing use of a constant (c684fd0)
- Removes several redundant access level keywords (2e094b4, 1d478cd)
- Removes one-liner Base-64 encode / decode methods (in favor of native equivalents) (12b5698)
- Removes redundant parentheses when throwing errors (02aa79b)
- Refactors random data generation (for Linux support) (715de9f)
- Makes `NaclUtil` public (b53274b)